### PR TITLE
Implement site context and pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Customer Admin Panel
 
 Minimal scaffold for a SaaS customer admin panel using React, TypeScript and Vite.
+It communicates with a NestJS backend using JWT authentication and a tenant header.
 
 ## Scripts
 
@@ -9,4 +10,33 @@ Minimal scaffold for a SaaS customer admin panel using React, TypeScript and Vit
 
 ## Environment Variables
 
-See `.env.example` for required variables.
+Create a `.env` file based on `.env.example` and provide values for:
+
+- `VITE_API_URL` – base URL of the API
+- `VITE_TOKEN_KEY` – key containing JWT token in `/auth/login` response
+- `VITE_AUTH_STORAGE_KEY` – localStorage key for storing the JWT
+- `VITE_TENANT_HEADER_NAME` – header name used for the tenant id
+
+The current token key is `access_token`.
+
+Requests that operate on site scoped resources automatically include the tenant header.
+
+Example:
+
+```bash
+VITE_API_URL=https://api.example.com
+VITE_TOKEN_KEY=access_token
+VITE_AUTH_STORAGE_KEY=saas_customer_token
+VITE_TENANT_HEADER_NAME=x-tenant-id
+```
+
+## Usage
+
+Install dependencies and start the dev server:
+
+```bash
+npm ci
+npm run dev
+```
+
+Login with a user that has the `site_owner` or `operator` role. Select a site from the top bar to manage its resources.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,28 +2,41 @@ import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
+import SitePage from './pages/Site';
+import PlansPage from './pages/Plans';
+import FeaturesPage from './pages/Features';
+import ThemePage from './pages/Theme';
+import PaymentsPage from './pages/Payments';
 import ProtectedRoute from './auth/ProtectedRoute';
 import { AuthProvider } from './auth/AuthContext';
 import Layout from './components/Layout';
+import { CurrentSiteProvider } from './auth/CurrentSiteContext';
 
 const App: React.FC = () => (
   <AuthProvider>
-    <Routes>
-      <Route path="/login" element={<Login />} />
-      <Route
-        path="/*"
-        element={
-          <ProtectedRoute>
-            <Layout>
-              <Routes>
+    <CurrentSiteProvider>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route
+          path="/*"
+          element={
+            <ProtectedRoute>
+              <Layout>
+                <Routes>
                 <Route path="/" element={<Dashboard />} />
-                <Route path="*" element={<Navigate to="/" replace />} />
-              </Routes>
-            </Layout>
-          </ProtectedRoute>
-        }
-      />
-    </Routes>
+                <Route path="/site" element={<SitePage />} />
+                <Route path="/plans" element={<PlansPage />} />
+                <Route path="/features" element={<FeaturesPage />} />
+                <Route path="/theme" element={<ThemePage />} />
+                <Route path="/payments" element={<PaymentsPage />} />
+                  <Route path="*" element={<Navigate to="/" replace />} />
+                </Routes>
+              </Layout>
+            </ProtectedRoute>
+          }
+        />
+      </Routes>
+    </CurrentSiteProvider>
   </AuthProvider>
 );
 

--- a/src/auth/CurrentSiteContext.tsx
+++ b/src/auth/CurrentSiteContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { setTenantId } from '../data/httpClient';
 
 interface CurrentSiteContextProps {
   siteId: string | null;
@@ -7,8 +8,24 @@ interface CurrentSiteContextProps {
 
 const CurrentSiteContext = createContext<CurrentSiteContextProps | undefined>(undefined);
 
+const STORAGE_KEY = 'saas_current_site';
+
 export const CurrentSiteProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [siteId, setSiteId] = useState<string | null>(null);
+  const [siteId, setSiteIdState] = useState<string | null>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      setSiteIdState(saved);
+      setTenantId(saved);
+    }
+  }, []);
+
+  const setSiteId = (id: string) => {
+    setSiteIdState(id);
+    localStorage.setItem(STORAGE_KEY, id);
+    setTenantId(id);
+  };
 
   return (
     <CurrentSiteContext.Provider value={{ siteId, setSiteId }}>

--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -11,7 +11,7 @@ const ProtectedRoute: React.FC<{ children: React.ReactElement }> = ({ children }
   }
 
   if (!['site_owner', 'operator'].includes(user.role)) {
-    return <div>Insufficient permissions.</div>;
+    return <div>403 - Access denied</div>;
   }
 
   return children;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import { AppBar, Toolbar, Typography, Box } from '@mui/material';
 import SiteSelector from './SiteSelector';
-import { setTenantId } from '../data/httpClient';
 
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const handleSiteChange = (id: string) => {
-    setTenantId(id);
-  };
 
   return (
     <Box>
@@ -15,7 +11,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
           <Typography variant="h6" sx={{ flexGrow: 1 }}>
             Customer Panel
           </Typography>
-          <SiteSelector onChange={handleSiteChange} />
+          <SiteSelector />
         </Toolbar>
       </AppBar>
       <Box sx={{ p: 2 }}>{children}</Box>

--- a/src/components/SiteSelector.tsx
+++ b/src/components/SiteSelector.tsx
@@ -1,21 +1,30 @@
 import React, { useEffect, useState } from 'react';
 import { MenuItem, Select } from '@mui/material';
 import api from '../data/httpClient';
+import { useCurrentSite } from '../auth/CurrentSiteContext';
 
 interface Site {
   id: string;
   name: string;
 }
 
-const SiteSelector: React.FC<{ onChange: (id: string) => void }> = ({ onChange }) => {
+const SiteSelector: React.FC = () => {
   const [sites, setSites] = useState<Site[]>([]);
+  const { siteId, setSiteId } = useCurrentSite();
 
   useEffect(() => {
-    api.get('/sites').then((res) => setSites(res.data));
+    api
+      .get('/sites', { params: { page: 1, limit: 100 } })
+      .then((res) => setSites(res.data?.data ?? res.data ?? []));
   }, []);
 
   return (
-    <Select size="small" onChange={(e) => onChange(e.target.value)} defaultValue="">
+    <Select
+      size="small"
+      onChange={(e) => setSiteId(e.target.value)}
+      value={siteId || ''}
+      displayEmpty
+    >
       <MenuItem value="" disabled>
         Select site
       </MenuItem>

--- a/src/data/httpClient.ts
+++ b/src/data/httpClient.ts
@@ -1,36 +1,44 @@
-import axios from 'axios';
+import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
 
 let tenantId: string | null = null;
+
 export const setTenantId = (id: string | null) => {
   tenantId = id;
 };
+
+const tokenKey = import.meta.env.VITE_AUTH_STORAGE_KEY || 'saas_customer_token';
+const tenantHeader = import.meta.env.VITE_TENANT_HEADER_NAME || 'x-tenant-id';
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
 });
 
-api.interceptors.request.use((config) => {
-  const token = localStorage.getItem(import.meta.env.VITE_AUTH_STORAGE_KEY || 'saas_customer_token');
+const siteBoundPaths = ['/site-plans', '/site-features', '/site-themes', '/payments'];
+
+api.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+  const token = localStorage.getItem(tokenKey);
   if (token) {
     config.headers = config.headers || {};
     config.headers.Authorization = `Bearer ${token}`;
   }
-  if (tenantId) {
+
+  if (tenantId && config.url && siteBoundPaths.some((p) => config.url?.includes(p))) {
     config.headers = config.headers || {};
-    const headerName = import.meta.env.VITE_TENANT_HEADER_NAME || 'x-tenant-id';
-    (config.headers as any)[headerName] = tenantId;
+    (config.headers as any)[tenantHeader] = tenantId;
   }
+
   return config;
 });
 
 api.interceptors.response.use(
   (response) => response,
-  (error) => {
+  (error: AxiosError) => {
     if (error.response?.status === 401) {
-      localStorage.removeItem(import.meta.env.VITE_AUTH_STORAGE_KEY || 'saas_customer_token');
+      localStorage.removeItem(tokenKey);
       window.location.href = '/login';
     }
-    return Promise.reject(error);
+    const message = (error.response?.data as any)?.message || error.message;
+    return Promise.reject(message);
   }
 );
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,18 @@
 import React from 'react';
-import { Typography, Container } from '@mui/material';
+import { Typography, Container, Alert } from '@mui/material';
+import { useCurrentSite } from '../auth/CurrentSiteContext';
 
 const Dashboard: React.FC = () => {
+  const { siteId } = useCurrentSite();
+
+  if (!siteId) {
+    return (
+      <Container sx={{ mt: 4 }}>
+        <Alert severity="info">Please select a site first.</Alert>
+      </Container>
+    );
+  }
+
   return (
     <Container>
       <Typography variant="h4" sx={{ mt: 4 }}>

--- a/src/pages/Features/index.tsx
+++ b/src/pages/Features/index.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import { Container, Table, TableHead, TableRow, TableCell, TableBody, Button, Alert } from '@mui/material';
+import api from '../../data/httpClient';
+import { useCurrentSite } from '../../auth/CurrentSiteContext';
+
+interface Feature {
+  id: string;
+  code: string;
+  name: string;
+  description?: string;
+  isActive: boolean;
+}
+
+interface SiteFeature {
+  id: string;
+  featureId: string;
+  isActive: boolean;
+}
+
+const FeaturesPage: React.FC = () => {
+  const { siteId } = useCurrentSite();
+  const [features, setFeatures] = useState<Feature[]>([]);
+  const [siteFeatures, setSiteFeatures] = useState<SiteFeature[]>([]);
+
+  useEffect(() => {
+    api.get('/features').then((res) => setFeatures(res.data?.data ?? res.data ?? []));
+  }, []);
+
+  useEffect(() => {
+    if (!siteId) return;
+    api.get('/site-features').then((res) => setSiteFeatures(res.data?.data ?? res.data ?? []));
+  }, [siteId]);
+
+  if (!siteId) {
+    return (
+      <Container sx={{ mt: 4 }}>
+        <Alert severity="info">Please select a site first.</Alert>
+      </Container>
+    );
+  }
+
+  const addFeature = async (featureId: string) => {
+    await api.post('/site-features', { featureId, isActive: true });
+    const { data } = await api.get('/site-features');
+    setSiteFeatures(data?.data ?? data ?? []);
+  };
+
+  const removeFeature = async (id: string) => {
+    await api.delete(`/site-features/${id}`);
+    const { data } = await api.get('/site-features');
+    setSiteFeatures(data?.data ?? data ?? []);
+  };
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Code</TableCell>
+            <TableCell>Name</TableCell>
+            <TableCell>Description</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {features.map((f) => {
+            const sf = siteFeatures.find((s) => s.featureId === f.id);
+            return (
+              <TableRow key={f.id}>
+                <TableCell>{f.code}</TableCell>
+                <TableCell>{f.name}</TableCell>
+                <TableCell>{f.description}</TableCell>
+                <TableCell>{sf ? (sf.isActive ? 'Active' : 'Inactive') : 'N/A'}</TableCell>
+                <TableCell>
+                  {sf ? (
+                    <Button size="small" onClick={() => removeFeature(sf.id)}>Remove</Button>
+                  ) : (
+                    <Button size="small" onClick={() => addFeature(f.id)}>Add</Button>
+                  )}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </Container>
+  );
+};
+
+export default FeaturesPage;

--- a/src/pages/Payments/index.tsx
+++ b/src/pages/Payments/index.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import { Container, Table, TableHead, TableRow, TableCell, TableBody, Alert } from '@mui/material';
+import api from '../../data/httpClient';
+import { useCurrentSite } from '../../auth/CurrentSiteContext';
+
+interface Payment {
+  id: string;
+  amountCents: number;
+  currency: string;
+  status: string;
+  invoiceNo?: string;
+  createdAt: string;
+}
+
+const PaymentsPage: React.FC = () => {
+  const { siteId } = useCurrentSite();
+  const [payments, setPayments] = useState<Payment[]>([]);
+
+  useEffect(() => {
+    if (!siteId) return;
+    api.get('/payments').then((res) => setPayments(res.data?.data ?? res.data ?? []));
+  }, [siteId]);
+
+  if (!siteId) {
+    return (
+      <Container sx={{ mt: 4 }}>
+        <Alert severity="info">Please select a site first.</Alert>
+      </Container>
+    );
+  }
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Amount</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell>Invoice</TableCell>
+            <TableCell>Date</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {payments.map((p) => (
+            <TableRow key={p.id}>
+              <TableCell>
+                {p.amountCents} {p.currency}
+              </TableCell>
+              <TableCell>{p.status}</TableCell>
+              <TableCell>{p.invoiceNo}</TableCell>
+              <TableCell>{new Date(p.createdAt).toLocaleDateString()}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Container>
+  );
+};
+
+export default PaymentsPage;

--- a/src/pages/Plans/index.tsx
+++ b/src/pages/Plans/index.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { Container, Table, TableHead, TableRow, TableCell, TableBody, Button, Alert } from '@mui/material';
+import api from '../../data/httpClient';
+import { useCurrentSite } from '../../auth/CurrentSiteContext';
+
+interface Plan {
+  id: string;
+  code: string;
+  name: string;
+  priceCents: number;
+  currency: string;
+  isActive: boolean;
+}
+
+const PlansPage: React.FC = () => {
+  const { siteId } = useCurrentSite();
+  const [plans, setPlans] = useState<Plan[]>([]);
+
+  useEffect(() => {
+    api.get('/plans').then((res) => setPlans(res.data?.data ?? res.data ?? []));
+  }, []);
+
+  if (!siteId) {
+    return (
+      <Container sx={{ mt: 4 }}>
+        <Alert severity="info">Please select a site first.</Alert>
+      </Container>
+    );
+  }
+
+  const upgrade = async (planId: string) => {
+    await api.post('/site-plans', { planId, isActive: true });
+    alert('Plan updated');
+  };
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Code</TableCell>
+            <TableCell>Name</TableCell>
+            <TableCell>Price</TableCell>
+            <TableCell>Active</TableCell>
+            <TableCell />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {plans.map((p) => (
+            <TableRow key={p.id}>
+              <TableCell>{p.code}</TableCell>
+              <TableCell>{p.name}</TableCell>
+              <TableCell>
+                {p.priceCents} {p.currency}
+              </TableCell>
+              <TableCell>{p.isActive ? 'Yes' : 'No'}</TableCell>
+              <TableCell>
+                <Button size="small" variant="contained" onClick={() => upgrade(p.id)}>
+                  Select
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Container>
+  );
+};
+
+export default PlansPage;

--- a/src/pages/Site/index.tsx
+++ b/src/pages/Site/index.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { Container, TextField, Button, Alert } from '@mui/material';
+import api from '../../data/httpClient';
+import { useCurrentSite } from '../../auth/CurrentSiteContext';
+
+interface SiteForm {
+  name: string;
+  slug: string;
+}
+
+const SitePage: React.FC = () => {
+  const { siteId } = useCurrentSite();
+  const { register, handleSubmit, reset } = useForm<SiteForm>();
+
+  useEffect(() => {
+    if (!siteId) return;
+    api.get(`/sites/${siteId}`).then((res) => reset(res.data));
+  }, [siteId, reset]);
+
+  if (!siteId) {
+    return (
+      <Container sx={{ mt: 4 }}>
+        <Alert severity="info">Please select a site first.</Alert>
+      </Container>
+    );
+  }
+
+  const onSubmit = async (data: SiteForm) => {
+    await api.put(`/sites/${siteId}`, data);
+    alert('Saved');
+  };
+
+  return (
+    <Container sx={{ mt: 4 }} maxWidth="sm">
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <TextField label="Name" fullWidth margin="normal" {...register('name', { required: true })} />
+        <TextField label="Slug" fullWidth margin="normal" {...register('slug', { required: true, pattern: /^[a-z0-9-]+$/ })} />
+        <Button variant="contained" type="submit">
+          Save
+        </Button>
+      </form>
+    </Container>
+  );
+};
+
+export default SitePage;

--- a/src/pages/Theme/index.tsx
+++ b/src/pages/Theme/index.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { Container, Grid, Card, CardContent, Typography, Button, Alert } from '@mui/material';
+import api from '../../data/httpClient';
+import { useCurrentSite } from '../../auth/CurrentSiteContext';
+
+interface Theme {
+  id: string;
+  code: string;
+  name: string;
+  description?: string;
+  isActive: boolean;
+}
+
+const ThemePage: React.FC = () => {
+  const { siteId } = useCurrentSite();
+  const [themes, setThemes] = useState<Theme[]>([]);
+  const [activeTheme, setActiveTheme] = useState<string>('');
+
+  useEffect(() => {
+    api.get('/themes').then((res) => setThemes(res.data?.data ?? res.data ?? []));
+  }, []);
+
+  useEffect(() => {
+    if (!siteId) return;
+    api.get('/site-themes', { params: { 'filter[isActive]': true } }).then((res) => {
+      const th = (res.data?.data ?? res.data ?? [])[0];
+      if (th) setActiveTheme(th.themeId);
+    });
+  }, [siteId]);
+
+  if (!siteId) {
+    return (
+      <Container sx={{ mt: 4 }}>
+        <Alert severity="info">Please select a site first.</Alert>
+      </Container>
+    );
+  }
+
+  const changeTheme = async (themeId: string) => {
+    await api.post('/site-themes', { themeId, isActive: true });
+    setActiveTheme(themeId);
+  };
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Grid container spacing={2}>
+        {themes.map((t) => (
+          <Grid item xs={12} sm={6} md={4} key={t.id}>
+            <Card variant={activeTheme === t.id ? 'outlined' : undefined}>
+              <CardContent>
+                <Typography variant="h6">{t.name}</Typography>
+                <Typography variant="body2" gutterBottom>
+                  {t.description}
+                </Typography>
+                <Button variant="contained" onClick={() => changeTheme(t.id)}>
+                  Activate
+                </Button>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Container>
+  );
+};
+
+export default ThemePage;


### PR DESCRIPTION
## Summary
- enhance API client with JWT/tenant header handling and error messages
- persist selected site in context
- restrict protected routes and site selection in dashboard
- add layout and site-related pages: Site, Plans, Features, Theme, Payments
- update README with env var usage

## Testing
- `npm ci`
- `npm run build`
- `npm run dev` *(starts vite server)*

------
https://chatgpt.com/codex/tasks/task_e_68879cb70e6483229f2a385691ddec69